### PR TITLE
Fix provisioning of binaries in poppler package

### DIFF
--- a/poppler.yaml
+++ b/poppler.yaml
@@ -53,12 +53,29 @@ pipeline:
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_INSTALL_PREFIX=/usr \
+      -DCMAKE_SYSTEM_NAME=Linux \
+      -DCMAKE_HOST_SYSTEM_NAME=Linux \
       -DENABLE_BOOST=ON \
       -DENABLE_GPGME=OFF \
       -DENABLE_LIBCURL=OFF \
       -DENABLE_QT5=OFF \
       -DENABLE_QT6=OFF \
-      -DENABLE_UNSTABLE_API_ABI_HEADERS=ON
-      cmake --build build
+      -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+      -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE \
+      -DCMAKE_INSTALL_RPATH=/usr/bin
+
+  - runs: |
+      cmake --build build     
+
+  - runs: |
+      DESTDIR="${{targets.destdir}}" cmake --install build
 
   - uses: strip
+
+#subpackages:
+#  - name: poppler-utils
+#    pipeline:
+#      - runs: |
+#          mkdir -p ${{targets.subpkgdir}}/usr
+#          mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
+#    description: Utils for The Berkeley DB embedded database system

--- a/poppler.yaml
+++ b/poppler.yaml
@@ -71,11 +71,3 @@ pipeline:
       DESTDIR="${{targets.destdir}}" cmake --install build
 
   - uses: strip
-
-#subpackages:
-#  - name: poppler-utils
-#    pipeline:
-#      - runs: |
-#          mkdir -p ${{targets.subpkgdir}}/usr
-#          mv ${{targets.destdir}}/usr/bin ${{targets.subpkgdir}}/usr/
-#    description: Utils for The Berkeley DB embedded database system


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "ruby-3.1: new package"
* "haproxy: fix CVE-2014-123456"
-->

<!--
Please include references to any related issues or delete this section otherwise.
 -->

Fixes:

Related:

### Pre-review Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.

At the moment of this PR you have the most information on what all the change
will affect, so please take the time to jot it down.

Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.

-->

#### For new package PRs only
<!-- remove if unrelated -->
- [ ] This PR is marked as fixing a pre-existing package request bug
  - [ ] Alternatively, the PR is marked as related to a pre-existing package request bug, such as a dependency
- [ ] REQUIRED - The package is available under an OSI-approved or FSF-approved license
- [ ] REQUIRED - The version of the package is still receiving security updates
- [ ] This PR links to the upstream project's support policy (e.g. `endoflife.date`)

#### For new version streams
<!-- remove if unrelated -->
- [ ] The upstream project actually supports multiple concurrent versions.
- [ ] Any subpackages include the version string in their package name (e.g. `name: ${{package.name}}-compat`)
- [ ] The package (and subpackages) `provides:` logical unversioned forms of the package (e.g. `nodejs`, `nodejs-lts`)

#### For security-related PRs
<!-- remove if unrelated -->
- [ ] The security fix is recorded in the [advisories](https://github.com/wolfi-dev/advisories) repo

#### For version bump PRs
<!-- remove if unrelated -->
- [ ] The `epoch` field is reset to 0

#### For PRs that add patches
<!-- remove if unrelated -->
- [ ] Patch source is documented
